### PR TITLE
Tilde operator to resolve dependency problem with Laravel 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "require": {
     "php": ">=5.4.0",
-    "illuminate/support" : "5.0.*|5.1.*"
+    "illuminate/support" : "~5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.6.*"


### PR DESCRIPTION
Composer was generating the following error when attempting install with Laravel 5.1:
 Problem 1
    - Installation request for mybb/gravatar  ~2.0.0 -> satisfiable by mybb/gravatar[v2.0.0].
    - Conclusion: remove laravel/framework v5.1.9
    - mybb/gravatar v2.0.0 requires illuminate/support 5.0.\* -> satisfiable by illuminate/support[v5.0.0, v5.0.22, v5.0.25, v5.0.26, v5.0.28, v5.0.33, v5.0.4].

Using the tilde operator for dependency check fixes the problem for me.
